### PR TITLE
serialize chart release and stop double-trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,10 @@ permissions:
   pages: write
   id-token: write
 
+concurrency:
+  group: chart-release
+  cancel-in-progress: false
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -111,6 +115,7 @@ jobs:
         uses: helm/chart-releaser-action@v1.6.0
         with:
           charts_dir: charts
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/update-appversion.yaml
+++ b/.github/workflows/update-appversion.yaml
@@ -8,6 +8,10 @@ permissions:
   contents: write
   actions: write
 
+concurrency:
+  group: chart-version-bump
+  cancel-in-progress: false
+
 jobs:
   update:
     runs-on: ubuntu-latest
@@ -52,10 +56,12 @@ jobs:
         run: |
           git add charts/logtide/Chart.yaml
           git commit -m "bump to logtide v${{ github.event.client_payload.version }}"
-          git push origin main
-
-      - name: Trigger release workflow
-        if: steps.bump.outputs.changed == 'true'
-        run: gh workflow run release.yaml --ref main
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          for attempt in 1 2 3; do
+            if git push origin main; then
+              exit 0
+            fi
+            echo "push rejected, rebasing on origin/main (attempt $attempt)"
+            git pull --rebase origin main
+          done
+          echo "failed to push after retries"
+          exit 1


### PR DESCRIPTION
This pull request introduces improvements to the GitHub Actions workflows for Helm chart releases and version bumps. The main changes add concurrency controls to prevent overlapping runs, improve the reliability of git pushes by retrying on failure, and ensure existing charts are not re-released.

Workflow reliability and concurrency:

* Added `concurrency` groups to both `.github/workflows/release.yaml` and `.github/workflows/update-appversion.yaml` to prevent multiple runs of the same workflow from overlapping. This helps avoid conflicts and ensures only one workflow run per group at a time. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR18-R21) [[2]](diffhunk://#diff-70f4fb84429a06bb1bc98b56c4687e3073fee5a516fd146361b6fab1af7c5d14R11-R14)
* Updated the git push step in `.github/workflows/update-appversion.yaml` to retry up to three times with a rebase if the push is rejected, improving reliability in the face of concurrent changes.

Helm chart release improvements:

* Set `skip_existing: true` for the `helm/chart-releaser-action` in `.github/workflows/release.yaml` to avoid errors when attempting to release charts that already exist.